### PR TITLE
Add FIG (Figma) deep dive analysis

### DIFF
--- a/docs/api/FIG.json
+++ b/docs/api/FIG.json
@@ -1,0 +1,81 @@
+{
+  "ticker": "FIG",
+  "company": "Figma, Inc.",
+  "sector": "Technology",
+  "industry": "Software — Collaborative Design Platform",
+  "exchange": "NYSE",
+  "price": 17.70,
+  "market_cap": "$9.33B",
+  "rating": "SPECULATIVE BUY",
+  "last_updated": "2026-05-01",
+  "thesis": "Figma is the dominant collaborative design platform with ~80-90% UI/UX market share, growing revenue at 40%+ with positive free cash flow ($246M, 23% margin) and 136% net revenue retention. The stock has cratered 88% from post-IPO highs due to SaaS multiple compression and AI anxiety, creating a disconnect between fundamentals and valuation. At ~7.2x EV/Revenue with $1.66B cash and minimal debt, Figma trades at a discount to peers despite superior growth. High short interest (26.5% of float) adds squeeze potential. Key risks: AI disruption, path to GAAP profitability, gross margin compression from 91% to 82%.",
+  "financials": {
+    "fiscal_year": "FY2025",
+    "revenue": "$1,056M",
+    "revenue_growth": "+40.96%",
+    "gross_margin": "82.43%",
+    "operating_margin": "-122.23%",
+    "net_income": "($1,250M)",
+    "eps_diluted": "($3.71)",
+    "free_cash_flow": "$246.2M",
+    "fcf_margin": "23.32%",
+    "cash": "$1.66B",
+    "debt": "$58.5M",
+    "enterprise_value": "$7.64B"
+  },
+  "bull_case": {
+    "target": "$55–65",
+    "drivers": [
+      "FY2026 revenue beats guidance ($1.4B+) with AI products accelerating adoption",
+      "Net revenue retention stays above 135% as enterprise customers expand seats",
+      "SaaS multiples re-rate higher as rates stabilize and growth scarcity premium returns",
+      "Path to GAAP profitability by 2028 as SBC moderates and operating leverage kicks in",
+      "Short squeeze from 26.5% short interest on any positive catalyst"
+    ]
+  },
+  "bear_case": {
+    "target": "$10–15",
+    "risks": [
+      "Revenue growth decelerates below 25% as AI-native tools (v0, Claude Design) erode share",
+      "Gross margins continue compressing below 80% due to AI compute costs",
+      "SBC remains elevated, preventing GAAP profitability and causing talent retention issues",
+      "Lockup expirations and insider selling create persistent supply overhang",
+      "Broader SaaS multiple compression pushes EV/Revenue below 5x"
+    ]
+  },
+  "base_case": {
+    "target": "$30–40",
+    "assumptions": "Revenue grows 30-35% in FY2026 to ~$1.35-1.4B; FCF margin stabilizes at 20-25%; SBC moderates to 30-35% of revenue; company reaches EBITDA breakeven by 2027; stock trades at 8-10x EV/Revenue as profitability path becomes visible"
+  },
+  "catalysts": [
+    {"date": "2026-05-14", "event": "Q1 2026 Earnings — guided $315-317M vs $291.9M consensus", "impact": "HIGH"},
+    {"date": "2026-08", "event": "Q2 2026 Earnings — mid-year guidance check", "impact": "MEDIUM"},
+    {"date": "2026-H2", "event": "Figma Make / Weave general availability launch", "impact": "MEDIUM"},
+    {"date": "2026-2027", "event": "IPO lockup expiration waves complete", "impact": "LOW-MEDIUM"}
+  ],
+  "key_risks": [
+    "AI disruption risk — AI-native design tools could commoditize Figma's core value proposition",
+    "No GAAP profitability with -$1.29B operating loss; path to earnings uncertain",
+    "Gross margin compression from 91% (2023) to 82% (2025) — trend direction matters",
+    "Massive SBC dilution: shares outstanding increased 72% YoY to 337M diluted",
+    "High short interest (26.5% of float) creates volatility but also squeeze potential",
+    "Recent IPO with limited trading history; lockup overhang may pressure stock further",
+    "SaaS sector multiple compression could persist if rates rise or recession fears intensify"
+  ],
+  "analyst_targets": {
+    "count": 8,
+    "consensus": "Hold / Moderate Buy",
+    "high": 60.0,
+    "low": 30.0,
+    "mean": 40.25,
+    "median": 38.50
+  },
+  "technical": {
+    "rsi_14": 47.55,
+    "rsi_date": "2026-04-30",
+    "fifty_two_week_low": 16.60,
+    "fifty_two_week_high": 142.92,
+    "short_percent_float": 0.265,
+    "short_ratio": 3.57
+  }
+}

--- a/docs/api/tickers.json
+++ b/docs/api/tickers.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-04-29",
+  "last_updated": "2026-05-01",
   "tickers": [
     {
       "ticker": "HIMS",
@@ -300,6 +300,18 @@
       "last_updated": "2026-04-29",
       "deep_dive_url": "/deep-dives/PPTA/",
       "api_url": "/api/PPTA.json"
+    },
+    {
+      "ticker": "FIG",
+      "company": "Figma, Inc.",
+      "sector": "Technology",
+      "industry": "Collaborative Design Platform",
+      "rating": "SPECULATIVE BUY",
+      "price": 17.70,
+      "market_cap": "$9.33B",
+      "last_updated": "2026-05-01",
+      "deep_dive_url": "/deep-dives/FIG/",
+      "api_url": "/api/FIG.json"
     }
   ]
 }

--- a/docs/deep-dives/FIG.md
+++ b/docs/deep-dives/FIG.md
@@ -1,0 +1,299 @@
+---
+title: "FIG — Figma"
+hide:
+  - navigation
+---
+
+
+[← Back to Summary](../index.md)
+
+# Figma, Inc. (FIG) - Comprehensive Deep Dive Analysis
+
+**Date:** May 1, 2026  
+**Current Price:** $17.70 (as of April 30, 2026 close)  
+**Market Cap:** ~$9.3B  
+**Sector:** Technology — Software Application  
+**Exchange:** NYSE  
+**Risk Rating:** HIGH (Recent IPO, Unprofitable, High Short Interest)  
+**Analyst Rating:** SPECULATIVE BUY
+
+---
+
+## Executive Summary
+
+Figma is the dominant collaborative design platform that went public in July 2025 at $33/share, briefly spiked above $100, and has since cratered **88% from its 52-week high of $142.92** to $17.70 today. The stock is caught in a perfect storm: post-IPO lockup expirations, broad SaaS multiple compression, and investor anxiety about AI disruption — yet the underlying business is growing revenue at 40%+ with positive free cash flow and 136% net revenue retention.
+
+**Key Investment Metrics at a Glance:**
+- **RSI:** 47.55 (neutral, recovering from oversold ~32 on April 24)
+- **Analyst Consensus:** Hold / Moderate Buy (8 analysts)
+- **Average Price Target:** $40.25 (representing ~127% upside)
+- **Revenue Growth:** 40.96% YoY (FY2025)
+- **NRR (Net Revenue Retention):** 136%
+- **Short Interest:** 26.5% of float (potential squeeze setup)
+- **Cash Position:** $1.66B (strong liquidity, minimal debt at $58.5M)
+
+**Bottom Line:** This is a high-quality growth business trading like a distressed asset. The disconnect between fundamentals (40% growth, positive FCF, dominant market position) and valuation (trading below IPO price with 127% analyst upside) creates an asymmetric opportunity — but only for investors who can stomach extreme volatility and a multi-year path to GAAP profitability.
+
+---
+
+## 1. COMPANY OVERVIEW
+
+### Business Model and Revenue Segments
+
+Figma, Inc. develops and sells a **collaborative, browser-based platform** for designing, prototyping, building digital experiences, and subscriptions for access to its platform. The company has evolved from a simple design tool into an AI-powered platform that spans the entire product development lifecycle.
+
+**Revenue Streams:**
+- **Platform Subscriptions (~95% of revenue):** Tiered SaaS subscriptions for Figma Design, FigJam, Figma Slides, and newer products
+- **Professional Services (~5%):** Training, implementation, and consulting
+
+**Product Portfolio:**
+
+| Product | Function | Status |
+|---------|----------|--------|
+| **Figma Design** | Collaborative UI/UX design tool with real-time multiplayer editing | Core product, ~80-90% UI/UX market share |
+| **FigJam** | Whiteboarding and ideation tool for teams | Growing adoption, complements Design |
+| **Figma Slides** | Presentation tool built for designers and their teams | Launched 2025, expanding TAM |
+| **Figma Draw** | Illustration tools for expressive designs | Newer addition |
+| **Figma Buzz** | Brand template publishing for social media, ads, one-pagers | Expanding into marketing use cases |
+| **Figma Sites** | Design, prototype, and publish websites directly from Figma | Challenging Webflow/Framer |
+| **Figma Make** | AI tool to design and prompt way to a functional prototype | AI monetization play |
+| **Figma Weave** | AI-powered media generation and editing | Deepening AI integration |
+| **Payload CMS** | Open-source headless CMS acquired by Figma | Content management layer |
+| **Code to Canvas** | Converts AI-generated code (Claude Code) into editable Figma designs | Anthropic partnership |
+
+*What this means:* Figma is expanding beyond pure design into the broader product development stack — prototyping, presentations, website publishing, and AI-assisted creation. This TAM expansion is the core bull case.
+
+### Industry Position & Competitive Moat
+
+**Market Position:** Figma dominates the UI/UX design space with an estimated **80-90% market share** among professional designers, having systematically displaced Adobe XD, Sketch, and InVision over the past decade.
+
+**Competitive Advantages:**
+- **Browser-native architecture:** Zero installation, works on any OS — was revolutionary when launched and still differentiates from Adobe's desktop-heavy suite
+- **Real-time collaboration:** Google Docs-style multiplayer editing became the industry standard Figma set
+- **Developer handoff:** Dev Mode bridges design-to-code gap, reducing friction in product teams
+- **Network effects:** 52,772+ companies using Figma; design systems and shared libraries create switching costs
+- **AI integration:** Partnership with Anthropic (Claude) positions Figma as the design layer for AI-generated code workflows
+
+**Competitive Threats:**
+- **Adobe Creative Cloud:** Still dominates high-end creative work; Adobe tried to acquire Figma for $20B in 2022 (deal blocked by EU regulators in 2023)
+- **Canva:** Dominates consumer and SMB segments; increasingly encroaching on professional design
+- **AI-native startups:** Tools like v0 (Vercel), Anthropic's Claude Design, and others could disrupt from below
+- **Open-source alternatives:** Penpot gaining traction among privacy-conscious and cost-sensitive users
+
+**Competitive Moat Assessment:** MODERATE-STRONG. The design tool market has high switching costs (design systems, team training, asset libraries), but AI is lowering the barrier to entry for competitors.
+
+### Management Team
+
+**CEO:** Dylan Field (co-founder, since 2012)  
+**CFO:** Not publicly disclosed in detail  
+**CTO:** Not publicly disclosed in detail
+
+**Key Executive Insights:**
+- Dylan Field has navigated Figma from startup to category leader to public company
+- Successfully fought off Adobe's $20B acquisition attempt, maintaining independence
+- Aggressive product expansion strategy (Slides, Sites, Make, Weave) suggests ambitious TAM expansion
+- Recent Anthropic partnership indicates forward-thinking AI strategy
+
+**Insider Ownership:** Significant founder control through dual-class structure  
+**Institutional Ownership:** Growing as lockups expire
+
+### Key Facilities & Geography
+- **Headquarters:** San Francisco, California
+- **Founded:** 2012
+- **Incorporation:** Delaware
+- **Employees:** Not disclosed in detail
+- **Global Presence:** Significant international revenue; browser-based model supports global teams natively
+
+---
+
+## 2. FINANCIAL ANALYSIS
+
+### Income Statement Trends
+
+| Metric | FY2024 | FY2025 | Change |
+|--------|--------|--------|--------|
+| **Revenue** | $749.0M | $1,056M | **+40.96%** |
+| **Cost of Revenue** | $87.5M | $185.5M | +112% |
+| **Gross Profit** | $661.5M | $870.2M | +31.5% |
+| **Gross Margin** | 88.32% | 82.43% | -589 bps |
+| **SG&A** | $787.8M | $1,131M | +43.5% |
+| **R&D** | $751.1M | $1,030M | +37.1% |
+| **Total Operating Expenses** | $1,539M | $2,161M | +40.4% |
+| **Operating Income** | -$877.4M | -$1,290M | Worsened |
+| **Net Income** | -$732.1M | -$1,250M | Worsened |
+| **EPS (Diluted)** | -$3.74 | -$3.71 | Slightly improved |
+| **Free Cash Flow** | -$63.7M | $246.2M | **+$309.9M** |
+| **FCF Margin** | -8.50% | 23.32% | +3,182 bps |
+
+**Key Observations:**
+- **Revenue growth remains stellar:** 40%+ YoY growth with $1B+ scale is rare in SaaS
+- **Gross margin compression:** Declined from 91.2% (2023) to 82.4% (2025) — still excellent but trending down; likely due to AI compute costs and infrastructure scaling
+- **Operating losses widening:** -$1.29B operating loss driven by aggressive R&D ($1.03B) and SG&A ($1.13B) investment
+- **FCF inflection:** Most important metric — FCF turned sharply positive at $246M (23% margin), proving the business can generate cash when it chooses to
+- **EPS barely improved:** -$3.71 vs -$3.74; massive share count increase from 196M to 337M diluted shares (+72%) offset any per-share progress
+
+### Balance Sheet Strength
+
+| Item | Amount | Notes |
+|------|--------|-------|
+| **Cash & Equivalents** | $1.66B | Strong liquidity post-IPO |
+| **Total Debt** | $58.5M | Minimal leverage |
+| **Net Cash** | ~$1.60B | ~17% of market cap in net cash |
+| **Enterprise Value** | ~$7.64B | EV/Revenue: ~7.2x |
+| **Shares Outstanding** | 444.3M | Significant dilution from IPO |
+| **Float** | 216.4M | ~49% of shares outstanding |
+
+**Balance Sheet Assessment:** Excellent. Figma has a fortress balance sheet with minimal debt and substantial cash. The company has runway for years even at current burn rates. The high cash position provides optionality for acquisitions, buybacks, or weathering downturns.
+
+### Cash Flow Analysis
+
+| Metric | FY2025 | Analysis |
+|--------|--------|----------|
+| **Operating Cash Flow** | $246.2M | Positive despite net losses — strong cash conversion |
+| **Free Cash Flow** | $246.2M | 23.3% margin; business generates real cash |
+| **FCF Per Share** | $0.73 | Positive on a per-share basis |
+
+**Cash Flow Quality:** The FCF inflection is the most bullish financial signal. Figma went from burning $63.7M in FY2024 to generating $246.2M in FY2025. This suggests the company is demonstrating operating leverage and can dial back SBC and opex to produce cash if needed. The gap between GAAP losses (-$1.25B) and FCF ($246M) is largely driven by non-cash stock-based compensation.
+
+---
+
+## 3. VALUATION
+
+### Multiples & Metrics
+
+| Metric | FIG | SaaS Median (High Growth) | Assessment |
+|--------|-----|---------------------------|------------|
+| **P/S (TTM)** | ~8.8x | 8-12x | Fair for 40% growth |
+| **EV/Revenue** | ~7.2x | 6-10x | Reasonable given cash position |
+| **Forward P/S (2026E)** | ~6.4x | 6-9x | Attractive if guidance met |
+| **P/E (TTM)** | N/A (unprofitable) | N/A | Not applicable |
+| **Forward P/E** | ~61.8x | 30-50x | High but will compress with earnings |
+| **EV/FCF** | ~31x | 25-40x | Reasonable for growth stage |
+
+**Valuation Assessment:** Figma trades at a discount to high-growth SaaS peers despite superior growth rates. The 40%+ revenue growth with positive FCF at a ~7x EV/Revenue multiple is compelling relative to peers trading at 10-15x with similar or lower growth. The negative GAAP earnings overstate the true economic cost due to massive SBC.
+
+### Scenario-Based Valuation
+
+| Scenario | Price Target | Key Assumptions |
+|----------|-------------|-----------------|
+| **Bull Case** | $55–65 | FY2026 revenue beats guidance ($1.4B+), AI products (Make, Weave) drive accelerated adoption, NRR stays above 135%, path to GAAP profitability by 2028, SaaS multiples re-rate higher |
+| **Base Case** | $30–40 | Revenue grows 30-35% in FY2026, FCF margin stabilizes at 20-25%, SBC moderates as % of revenue, company reaches EBITDA breakeven by 2027, stock trades at 8-10x EV/Revenue |
+| **Bear Case** | $10–15 | Revenue growth decelerates below 25%, AI competition erodes market share, gross margins continue compressing, cash burn resumes, further multiple compression in SaaS sector |
+
+**Probability-Weighted Target:** ~$35 (representing ~98% upside from current levels)
+
+---
+
+## 4. GROWTH CATALYSTS
+
+1. **AI Product Monetization (Figma Make, Weave, Code to Canvas):** The Anthropic partnership and AI-native features represent a new revenue layer. If Figma can charge premium pricing for AI-assisted design, this accelerates both growth and margins.
+
+2. **TAM Expansion (Slides, Sites, Buzz):** Each new product category expands Figma's addressable market beyond pure design. Figma Slides attacks PowerPoint/Keynote. Figma Sites challenges Webflow. These products have lower switching costs but leverage existing user relationships.
+
+3. **Enterprise Penetration:** With 136% NRR, existing customers are expanding seats and products. Landing-and-expanding within large enterprises (Fortune 500, tech companies) provides predictable growth.
+
+4. **International Expansion:** Browser-native architecture and real-time collaboration translate well globally. International markets likely underpenetrated relative to U.S.
+
+5. **Short Squeeze Potential:** 26.5% short interest with only 3.57 days to cover creates technical upside. Any positive catalyst (earnings beat, AI product launch, analyst upgrade) could force covering.
+
+6. **Q1 2026 Earnings (May 14, 2026):** Company guided $315-317M vs $291.9M consensus. A beat could re-rate the stock significantly.
+
+---
+
+## 5. RISKS
+
+1. **AI Disruption Risk (HIGH):** The core threat is that AI makes design tools obsolete or commodity. If developers can generate UIs directly from prompts (v0, Claude Design, etc.), Figma's design-tool moat erodes. The Anthropic partnership is a hedge, but Figma must successfully integrate AI without cannibalizing core subscriptions.
+
+2. **GAAP Profitability Path (MEDIUM-HIGH):** Figma burned $1.29B in operating losses in FY2025. While FCF is positive, that's largely because SBC is a non-cash expense. If employees demand more cash compensation or SBC dilution limits talent retention, the economic model changes.
+
+3. **Gross Margin Compression (MEDIUM):** Gross margins declined from 91.2% (2023) to 82.4% (2025). If AI compute costs and infrastructure scaling continue pressuring margins, the long-term margin profile may be lower than premium SaaS peers.
+
+4. **Competition from Adobe and Canva (MEDIUM):** Adobe has the resources to build or buy competitive products. Canva is aggressively moving upmarket. Both are larger and more diversified than Figma.
+
+5. **Lockup/Insider Selling Overhang (MEDIUM):** As IPO lockups expire, insider selling could pressure the stock further. The stock is already down 88% from highs, but additional supply could cap near-term appreciation.
+
+6. **SaaS Multiple Compression (MEDIUM):** The broader software sector has experienced multiple compression as interest rates normalized. If rates rise further or recession fears intensify, Figma could face additional derating regardless of fundamentals.
+
+7. **Customer Concentration in Tech (LOW-MEDIUM):** Tech sector layoffs and budget cuts could impact Figma's core customer base. The 136% NRR suggests strong health, but a tech downturn would slow expansion revenue.
+
+---
+
+## 6. TECHNICAL ANALYSIS
+
+**Current RSI (14):** 47.55 — neutral territory, recovering from oversold conditions (RSI ~32 on April 24, 2026)
+
+**Price Action:**
+- **All-time high:** ~$142.92 (post-IPO spike)
+- **Current price:** $17.70
+- **Drawdown from highs:** -87.6%
+- **vs IPO price ($33):** -46.4% below IPO
+- **52-week low:** $16.60 (set April 2026)
+- **Trend:** Violent downtrend since IPO spike; recent stabilization near $16-18 range
+
+**Support/Resistance Levels:**
+- **Support:** $16.60 (52-week low) — psychological level; a break below opens downside to $12-14
+- **Resistance:** $21-22 (recent local highs), then $28-30 (post-earnings spike zone from February 2026)
+
+**Volume Patterns:** Elevated volume on down days suggests distribution; recent stabilization on lower volume may indicate selling exhaustion.
+
+**Short Interest Dynamics:** 26.5% of float shorted with 3.57 days to cover. This is extremely high and creates asymmetric technical upside on positive news.
+
+![FIG RSI Chart](../../memory/FIG_RSI_2026-05-01.png)
+
+---
+
+## 7. RECOMMENDATION
+
+### Summary Rating: **SPECULATIVE BUY**
+
+| Factor | Assessment | Weight |
+|--------|------------|--------|
+| **Growth** | ★★★★★ | 25% |
+| **Profitability** | ★★☆☆☆ | 20% |
+| **Valuation** | ★★★★☆ | 20% |
+| **Balance Sheet** | ★★★★★ | 15% |
+| **Risk Profile** | ★★★☆☆ | 20% |
+
+**Weighted Score:** 3.55 / 5.0 — Above average for a speculative growth stock
+
+### Position Sizing Guidance
+
+| Investor Type | Allocation | Rationale |
+|---------------|------------|-----------|
+| Aggressive | 5-8% | High conviction on AI integration and market dominance; accepts volatility |
+| Moderate | 2-4% | Quality growth at distressed price; trim if breaks $16 support |
+| Conservative | 0-1% | Wait for GAAP profitability or sustained FCF margin >25% |
+
+### Catalyst Calendar
+
+| Date | Event | Impact |
+|------|-------|--------|
+| **May 14, 2026** | Q1 2026 Earnings | HIGH — guided $315-317M vs $291.9M consensus; beat could spark re-rating |
+| **August 2026** | Q2 2026 Earnings | MEDIUM — mid-year guidance check; AI product adoption metrics |
+| **2026 H2** | Figma Make / Weave GA | MEDIUM — AI product launches could accelerate growth |
+| **Ongoing** | Lockup expirations | LOW-MEDIUM — potential selling pressure as restrictions lift |
+
+---
+
+## SOURCES CONSULTED
+
+- [x] Yahoo Finance — [FIG Quote](https://finance.yahoo.com/quote/FIG/)
+- [x] StockAnalysis.com — [FIG Overview](https://stockanalysis.com/stocks/fig/)
+- [x] Seeking Alpha — [FIG Analysis](https://seekingalpha.com/symbol/FIG)
+- [x] Benzinga — [Q4 2025 Earnings Report](https://www.benzinga.com/markets/earnings/26/02/50706194/figma-stock-rallies-after-q4-earnings-heres-why)
+- [x] CNBC — [Anthropic Partnership](https://www.cnbc.com/2026/02/17/figma-anthropic-ai-code-designs.html)
+- [x] MarketBeat — [Analyst Forecasts](https://www.marketbeat.com/stocks/NYSE/FIG/forecast/)
+- [x] TipRanks — [Price Targets](https://www.tipranks.com/stocks/fig/forecast)
+- [x] Public.com — [Stock Forecast](https://public.com/stocks/fig/forecast-price-target)
+- [x] TradingView — [Anthropic Integration Analysis](https://www.tradingview.com/news/marketbeat:9557040e9094b:0-figma-s-anthropic-integration-could-flip-the-saaspocalypse-script/)
+- [x] Figma Blog — [IPO Pricing Announcement](https://www.figma.com/blog/ipo-pricing/)
+- [x] AlphaSense — [Creative Cloud Market Analysis](https://www.alpha-sense.com/resources/research-articles/figma-creative-cloud-market/)
+- [x] Company Investor Relations — [investor.figma.com](https://investor.figma.com/)
+- [x] SEC Filings (10-K, S-1)
+
+---
+
+**Disclaimer:** This analysis is for informational purposes only and does not constitute investment advice. FIG is a recent IPO with limited trading history, significant volatility, and no GAAP profitability. Past performance does not guarantee future results.
+
+**Report Generated:** May 1, 2026  
+**Next Update:** Post-Q1 2026 Earnings (May 14, 2026)

--- a/docs/deep-dives/technology.md
+++ b/docs/deep-dives/technology.md
@@ -20,6 +20,7 @@ title: Technology
 | **SATS** | EchoStar | <span class="rating-buy">ACCUMULATE</span> | $135.11 | 2026-04-04 | [:material-file-document: Read](SATS.md) |
 | **INFQ** | Infleqtion | <span class="rating-spec-buy">SPEC. BUY</span> | $12.02 | 2026-04-29 | [:material-file-document: Read](INFQ.md) |
 | **NBIS** | Nebius Group | <span class="rating-spec-buy">SPEC. BUY</span> | $158.34 | 2026-04-22 | [:material-file-document: Read](NBIS.md) |
+| **FIG** | Figma | <span class="rating-spec-buy">SPEC. BUY</span> | $17.70 | 2026-05-01 | [:material-file-document: Read](FIG.md) |
 
 ---
 
@@ -112,6 +113,16 @@ First publicly traded neutral-atom quantum technology company, delivering quantu
 **Bull:** $28–35 · **Base:** $16–22 · **Bear:** $5–8
 
 [:material-arrow-right: Full Deep Dive](INFQ.md)
+
+---
+
+### FIG — Figma · <span class="rating-spec-buy">SPEC. BUY</span> · $17.70
+
+Dominant collaborative design platform with ~80-90% UI/UX market share, growing revenue at 40%+ with positive free cash flow ($246M, 23% margin) and 136% net revenue retention. Stock has cratered 88% from post-IPO highs due to SaaS multiple compression and AI anxiety, creating a disconnect between fundamentals and valuation. At ~7.2x EV/Revenue with $1.66B cash and minimal debt, Figma trades at a discount to peers despite superior growth. High short interest (26.5% of float) adds squeeze potential. Anthropic partnership (Code to Canvas) and AI products (Figma Make, Weave) represent new monetization layers. Next catalyst: Q1 2026 earnings May 14, guided $315-317M vs $291.9M consensus.
+
+**Bull:** $55–65 · **Base:** $30–40 · **Bear:** $10–15
+
+[:material-arrow-right: Full Deep Dive](FIG.md)
 
 ---
 

--- a/docs/table.md
+++ b/docs/table.md
@@ -26,5 +26,6 @@
 | **CRCL** | Circle Internet Group | <span class="badge badge-fintech">Fintech</span> | <span class="rating-buy">BUY</span> | $106.36 | 2026-04-21 | [:material-file-document: Read](deep-dives/CRCL.md) |
 | **INFQ** | Infleqtion | <span class="badge badge-tech">Technology</span> | <span class="rating-spec-buy">SPEC. BUY</span> | $12.02 | 2026-04-29 | [:material-file-document: Read](deep-dives/INFQ.md) |
 | **PPTA** | Perpetua Resources | <span class="badge badge-materials">Materials</span> | <span class="rating-spec-buy">SPEC. BUY</span> | $26.30 | 2026-04-29 | [:material-file-document: Read](deep-dives/PPTA.md) |
+| **FIG** | Figma | <span class="badge badge-tech">Technology</span> | <span class="rating-spec-buy">SPEC. BUY</span> | $17.70 | 2026-05-01 | [:material-file-document: Read](deep-dives/FIG.md) |
 
 ---


### PR DESCRIPTION
- Full 11-section deep dive report (docs/deep-dives/FIG.md)
- Structured API data (docs/api/FIG.json)
- RSI chart saved to memory/FIG_RSI_2026-05-01.png
- Updated docs/table.md with FIG entry
- Updated docs/deep-dives/technology.md with table row + gist
- Updated docs/api/tickers.json with FIG metadata

Key metrics:
- Price: 7.70 (down 88% from 52W high)
- Revenue: .056B (+40.96% YoY)
- FCF: 46.2M (23.3% margin)
- NRR: 136%
- Short interest: 26.5% of float
- RSI: 47.55
- Rating: SPECULATIVE BUY
- Analyst mean target: 0.25 (127% upside)